### PR TITLE
Renere template med valgmulighet på wrapper og wrappers css-klasse.

### DIFF
--- a/assets/template.php
+++ b/assets/template.php
@@ -13,10 +13,4 @@ if ( ! defined( 'ABSPATH' ) || ! ( $this instanceof Text ) ) {
 	return; // Exit if accessed directly.
 }
 
-?>
-
-<section class="<?php echo esc_attr( $this->get_wrapper_classes( true ) ); ?>">
-	<article class="columns">
-		<?php echo wp_kses_post( $this->content ); ?>
-	</article>
-</section>
+echo wp_kses_post( $this->content );

--- a/class-text.php
+++ b/class-text.php
@@ -68,10 +68,10 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Text' ) ) {
 			parent::load_args_from_layout_content( $content );
 
 			// Wrap text module content in <article> tag inside the global <section> tag.
-			if ( true === apply_filters( 'hogan/module/text/wrap_content_in_article', true ) ) {
+			if ( true === apply_filters( 'hogan/module/text/wrap_content_in_article', true, $this ) ) {
 
 				// CSS classes for <article> wrapper.
-				$classes = apply_filters( 'hogan/module/text/template/article/classes', [] );
+				$classes = apply_filters( 'hogan/module/text/template/article/classes', [], $this );
 				$classes = trim( implode( ' ', array_filter( $classes ) ) );
 
 				add_action( 'hogan/module/text/template/before_include', function() use ( $classes ) {

--- a/class-text.php
+++ b/class-text.php
@@ -67,19 +67,19 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Text' ) ) {
 
 			parent::load_args_from_layout_content( $content );
 
-			// Wrap text module content in <article> tag inside the global <section> tag.
-			if ( true === apply_filters( 'hogan/module/text/wrap_content_in_article', true, $this ) ) {
+			// Wrap text module content in <div> tag inside the global <section> tag.
+			if ( true === apply_filters( 'hogan/module/text/wrap_content_in_div', true, $this ) ) {
 
-				// CSS classes for <article> wrapper.
-				$classes = apply_filters( 'hogan/module/text/template/article/classes', [], $this );
+				// CSS classes for <div> wrapper.
+				$classes = apply_filters( 'hogan/module/text/template/div/classes', [], $this );
 				$classes = trim( implode( ' ', array_filter( $classes ) ) );
 
 				add_action( 'hogan/module/text/template/before_include', function() use ( $classes ) {
-					echo sprintf( '<article class="%s">', esc_attr( $classes ) );
+					echo sprintf( '<div class="%s">', esc_attr( $classes ) );
 				} );
 
 				add_action( 'hogan/module/text/template/after_include', function() {
-					echo '</article>';
+					echo '</div>';
 				} );
 
 			}

--- a/class-text.php
+++ b/class-text.php
@@ -66,6 +66,23 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Text' ) ) {
 			$this->content = $content['content'];
 
 			parent::load_args_from_layout_content( $content );
+
+			// Wrap text module content in <article> tag inside the global <section> tag.
+			if ( true === apply_filters( 'hogan/module/text/wrap_content_in_article', true ) ) {
+
+				// CSS classes for <article> wrapper.
+				$classes = apply_filters( 'hogan/module/text/template/article/classes', [] );
+				$classes = trim( implode( ' ', array_filter( $classes ) ) );
+
+				add_action( 'hogan/module/text/template/before_include', function() use ( $classes ) {
+					echo sprintf( '<article class="%s">', esc_attr( $classes ) );
+				} );
+
+				add_action( 'hogan/module/text/template/after_include', function() {
+					echo '</article>';
+				} );
+
+			}
 		}
 	}
 }

--- a/hogan-text.php
+++ b/hogan-text.php
@@ -22,10 +22,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once 'class-text.php';
 
-add_action( 'plugins_loaded', function() {
-	load_plugin_textdomain( 'hogan-text', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-} );
+add_action( 'plugins_loaded', 'hogan_text_load_textdomain' );
+add_action( 'hogan/include_modules', 'hogan_text_register_module' );
 
-add_action( 'hogan/include_modules', function() {
+/**
+ * Register module text domain
+ */
+function hogan_text_load_textdomain() {
+	load_plugin_textdomain( 'hogan-text', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+
+/**
+ * Register module in Hogan
+ */
+function hogan_text_register_module() {
 	hogan_register_module( new \Dekode\Hogan\Text() );
-} );
+}


### PR DESCRIPTION
Dagens mal til tekstmodulen har en hardkodet `<article class="columns">` wrapper rundt innholdet som ikke er mulig å fjerne uten å overstyre med egendefinert mal.

Forslag fra @pederan var å endre dette til dynamisk kode som at man kan:
1. Velge å ikke ha med wrapper i det hele tatt. (`hogan/module/text/wrap_content_in_div = false`)
2. Sette klassenavn via filter, feks `columns` hvis man benytter [Foundation Grid](https://foundation.zurb.com/grid.html).
3. Sette klassenavn basert på innholdet til en enkeltmodul (ala det vi allerede kan for `<section>` wrapperen.

Proof of Concept:
```php
add_filter( 'hogan/module/text/template/div/classes', function( $classes, $module ) {
    $classes[] = 'columns';
    return $classes;
}, 10 2 );
```

