### PR TITLE
Remove wp_kses_post for oEmbed support, Fixes #6

### DIFF
--- a/assets/template.php
+++ b/assets/template.php
@@ -17,4 +17,4 @@ if ( ! defined( 'ABSPATH' ) || ! ( $this instanceof Text ) ) {
 	return; // Exit if accessed directly.
 }
 
-echo $this->content; //phpcs:ignore
+echo $this->content; // WPCS: XSS OK.

--- a/assets/template.php
+++ b/assets/template.php
@@ -17,4 +17,4 @@ if ( ! defined( 'ABSPATH' ) || ! ( $this instanceof Text ) ) {
 	return; // Exit if accessed directly.
 }
 
-echo wp_kses_post( $this->content );
+echo $this->content; //phpcs:ignore


### PR DESCRIPTION
Remove use of `wp_kses_post()` in module template allow use of inline oEmbeds. #6 