### PR TITLE
Update module registration (Fixes #10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": ">=7.0",
     "composer/installers": "~1.2",
-    "dekodeinteraktiv/hogan-core": "^1.0"
+    "dekodeinteraktiv/hogan-core": ">=1.1.7"
   },
   "archive": {
     "exclude": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2166fbd96906dcf9e725bde1f6a8d1c8",
+    "content-hash": "5ed8421425f385fa5c5bc3a3ef91ab80",
     "packages": [
         {
             "name": "composer/installers",
@@ -128,21 +128,24 @@
         },
         {
             "name": "dekodeinteraktiv/hogan-core",
-            "version": "1.1.4",
+            "version": "1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DekodeInteraktiv/hogan-core.git",
-                "reference": "7d51095d7c0d568eb177cb28fde36ebdc216039a"
+                "reference": "46d5dd20ad7388ee014bc74efdde9261bb2c2ac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DekodeInteraktiv/hogan-core/zipball/7d51095d7c0d568eb177cb28fde36ebdc216039a",
-                "reference": "7d51095d7c0d568eb177cb28fde36ebdc216039a",
+                "url": "https://api.github.com/repos/DekodeInteraktiv/hogan-core/zipball/46d5dd20ad7388ee014bc74efdde9261bb2c2ac0",
+                "reference": "46d5dd20ad7388ee014bc74efdde9261bb2c2ac0",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "~1.2",
                 "php": ">=7.0"
+            },
+            "require-dev": {
+                "dekodeinteraktiv/coding-standards": "^0.3.1"
             },
             "type": "wordpress-plugin",
             "notification-url": "https://packagist.org/downloads/",
@@ -151,7 +154,7 @@
             ],
             "description": "Modular Flexible Content System for ACF Pro",
             "homepage": "https://github.com/DekodeInteraktiv/hogan-core",
-            "time": "2018-03-23T09:10:19+00:00"
+            "time": "2018-04-04T09:25:18+00:00"
         }
     ],
     "packages-dev": [

--- a/hogan-text.php
+++ b/hogan-text.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\hogan_text_load_textdomain' );
-add_action( 'hogan/include_modules', __NAMESPACE__ . '\\hogan_text_register_module' );
+add_action( 'hogan/include_modules', __NAMESPACE__ . '\\hogan_text_register_module', 10, 1 );
 
 /**
  * Register module text domain
@@ -39,9 +39,10 @@ function hogan_text_load_textdomain() {
 /**
  * Register module in Hogan
  *
+ * @param \Dekode\Hogan\Core $core Hogan Core instance.
  * @return void
  */
-function hogan_text_register_module() {
+function hogan_text_register_module( \Dekode\Hogan\Core $core ) {
 	require_once 'class-text.php';
-	\hogan_register_module( new \Dekode\Hogan\Text() );
+	$core->register_module( new \Dekode\Hogan\Text() );
 }

--- a/hogan-text.php
+++ b/hogan-text.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/dekodeinteraktiv/hogan-text
  * GitHub Plugin URI: https://github.com/dekodeinteraktiv/hogan-text
  * Description: WYSIWYG Text Module for Hogan
- * Version: 1.0.5
+ * Version: 1.0.6
  * Author: Dekode
  * Author URI: https://dekode.no
  * License: GPL-3.0-or-later


### PR DESCRIPTION
- Update module to new registration method introduced in [Hogan Core 1.1.7](https://github.com/DekodeInteraktiv/hogan-core/releases/tag/1.1.7)
- Set hogan-core dependency `"dekodeinteraktiv/hogan-core": ">=1.1.7"`
- Version bump to 1.0.6
